### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL := /bin/bash
 PYTHON=python3.8
 DJANGO_MANAGE=api/manage.py
 ENV_DIR=.$(PYTHON)_env
-IN_ENV=.$(ENV_DIR)/bin/activate
+IN_ENV= source $(ENV_DIR)/bin/activate
 
 all:
 	@./.djengu/create.sh


### PR DESCRIPTION
The Error was in the activation of VIRTUALENV
using the command

> .python3.8_env/bin/activate && pip3 install -r api/requirements.txt

the command accepted in my case was

>  source .python3.8_env/bin/activate && pip3 install -r api/requirements.txt

Added 'source' command in:

> IN_ENV= source $(ENV_DIR)/bin/activate